### PR TITLE
Missing cffi backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,2 @@
 # Python
 This repo contains python programs.
-
-## Setup
-Install runtime dependencies (including `cffi`, required by `cryptography`):
-
-```bash
-python3 -m pip install -r requirements.txt
-```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Python
 This repo contains python programs.
+
+## Setup
+Install runtime dependencies (including `cffi`, required by `cryptography`):
+
+```bash
+python3 -m pip install -r requirements.txt
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+cffi==2.0.0
+cryptography==46.0.4
+pymongo==4.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
-cffi==2.0.0
-cryptography==46.0.4
-pymongo==4.16.0
+pymongo
+dnspython
+pandas
+boto3
+cx_Oracle
+cffi
+cryptography


### PR DESCRIPTION
Add `requirements.txt` and update `README.md` to ensure `cffi` and `cryptography` are correctly installed, resolving `ModuleNotFoundError: No module named '_cffi_backend'`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b726573b-4881-4777-9ade-df4f37a742c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b726573b-4881-4777-9ade-df4f37a742c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

